### PR TITLE
fix: escape backslashes in originalGit path

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var mockBin = require('mock-bin');
 var which = require('shelljs').which;
 
 module.exports = function (js, command) {
-	var originalGit = which('git');
+	var originalGit = which('git').stdout.replace(new RegExp('\\\\', 'g'), '\\\\');
 
 	if (command) {
 		js = 'var argv = process.argv;' +

--- a/test.js
+++ b/test.js
@@ -59,18 +59,22 @@ test('mocking git', async t => {
 	const log = 'mocking git!';
 	const unmock = await m(`console.log('${log}')`);
 
-	let actual = shell.exec('git').stdout;
-	t.is(log + '\n', actual);
+	let actual = shell.exec('git');
+	t.is(log + '\n', actual.stdout);
+	t.falsy(actual.stderr);
 
-	actual = shell.exec('git foo').stdout;
-	t.is(log + '\n', actual);
+	actual = shell.exec('git foo');
+	t.is(log + '\n', actual.stdout);
+	t.falsy(actual.stderr);
 
-	actual = shell.exec('git --no-pager log').stdout;
-	t.is(log + '\n', actual);
+	actual = shell.exec('git --no-pager log');
+	t.is(log + '\n', actual.stdout);
+	t.falsy(actual.stderr);
 
 	unmock();
-	actual = shell.exec('git').stdout;
-	t.not(log + '\n', actual);
+	actual = shell.exec('git');
+	t.not(log + '\n', actual.stdout);
+	t.falsy(actual.stderr);
 });
 
 test('passing arguments while mocking only commit', async t => {


### PR DESCRIPTION
Fix windows paths (and potentially others) by escaping
backslashes that are inserted into the mock-git js.
