### PR TITLE
fix: pass through exit code from child process

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,13 @@ module.exports = function (js, command) {
 			'if (commandExists) {' +
 				js +
 			'} else {' +
+				'function handleExitCode(code) { process.exitCode = code || 0; }' +
 				'var childProcess = require("child_process");' +
 				'argv.shift();' +
 				'argv.shift();' +
 				'childProcess.spawn("' + originalGit + '", argv, {' +
 					'stdio: "inherit"' +
-				'});' +
+				'}).on("close", handleExitCode).on("exit", handleExitCode);' +
 			'}';
 	}
 

--- a/test.js
+++ b/test.js
@@ -98,3 +98,23 @@ test('passing arguments while mocking whole git', async t => {
 
 	unmock();
 });
+
+test('passing through exit code', async t => {
+	const unmock = await m('process.exitCode = 1');
+	const args = 'foo';
+
+	const actual = shell.exec(`git ${args}`);
+	t.is(1, actual.code);
+
+	unmock();
+});
+
+test('passing through exit code with multiple mocks', async t => {
+	const unmock = [await m('process.exitCode = 1', 'one'), await m('process.exitCode = 2', 'two')];
+
+	t.is(1, shell.exec(`git one`).code);
+	t.is(2, shell.exec(`git two`).code);
+
+	unmock[0]();
+	unmock[1]();
+});


### PR DESCRIPTION
This is essential in order to simulate Git error conditions. I need this for [git-exec-and-restage](https://github.com/motiz88/git-exec-and-restage) and have switched to using the forked `mock-git` temporarily.